### PR TITLE
:invalid_order_key_head should not raise a MatchError

### DIFF
--- a/lib/fractional_index.ex
+++ b/lib/fractional_index.ex
@@ -133,12 +133,13 @@ defmodule FractionalIndex do
   def validate_order_key("A00000000000000000000000000"), do: :invalid_key
 
   def validate_order_key(key) do
-    {:ok, i} = get_integer_part(key)
-    f = String.slice(key, String.length(i)..String.length(key))
+    with {:ok, i} <- get_integer_part(key) do
+      f = String.slice(key, String.length(i)..String.length(key))
 
-    case String.last(f) do
-      "0" -> :invalid_key
-      _ -> :ok
+      case String.last(f) do
+        "0" -> :invalid_key
+        _ -> :ok
+      end
     end
   end
 

--- a/test/fractional_index_test.exs
+++ b/test/fractional_index_test.exs
@@ -47,9 +47,43 @@ defmodule FractionalIndexTest do
     assert {:ok, "ZzV"} = FractionalIndex.generate_key_between("Zz", "a0")
     assert {:ok, "a0"} = FractionalIndex.generate_key_between("Zz", "a01")
     assert {:ok, "Zz"} = FractionalIndex.generate_key_between(nil, "a0")
+    assert {:ok, "Zy"} == FractionalIndex.generate_key_between(nil, "Zz")
+    assert {:ok, "a1"} == FractionalIndex.generate_key_between("a0", nil)
+    assert {:ok, "a2"} == FractionalIndex.generate_key_between("a1", nil)
+    assert {:ok, "a0V"} == FractionalIndex.generate_key_between("a0", "a1")
+    assert {:ok, "a1V"} == FractionalIndex.generate_key_between("a1", "a2")
+    assert {:ok, "a0l"} == FractionalIndex.generate_key_between("a0V", "a1")
+    assert {:ok, "a0"} == FractionalIndex.generate_key_between("Zz", "a1")
+    assert {:ok, "Xzzz"} == FractionalIndex.generate_key_between(nil, "Y00")
+    assert {:ok, "c000"} == FractionalIndex.generate_key_between("bzz", nil)
+    assert {:ok, "a0G"} == FractionalIndex.generate_key_between("a0", "a0V")
+    assert {:ok, "a08"} == FractionalIndex.generate_key_between("a0", "a0G")
+    assert {:ok, "b127"} == FractionalIndex.generate_key_between("b125", "b129")
+    assert {:ok, "a1"} == FractionalIndex.generate_key_between("a0", "a1V")
+    assert {:ok, "a0"} == FractionalIndex.generate_key_between("Zz", "a01")
+    assert {:ok, "a0"} == FractionalIndex.generate_key_between(nil, "a0V")
+    assert {:ok, "b99"} == FractionalIndex.generate_key_between(nil, "b999")
+
+    assert {:ok, "A000000000000000000000000000V"} ==
+             FractionalIndex.generate_key_between(nil, "A000000000000000000000000001")
+
+    assert {:ok, "zzzzzzzzzzzzzzzzzzzzzzzzzzz"} ==
+             FractionalIndex.generate_key_between("zzzzzzzzzzzzzzzzzzzzzzzzzzy", nil)
+
+    assert {:ok, "zzzzzzzzzzzzzzzzzzzzzzzzzzzV"} ==
+             FractionalIndex.generate_key_between("zzzzzzzzzzzzzzzzzzzzzzzzzzz", nil)
   end
 
   test ":invalid_order_key_head does not raise a MatchError" do
     assert {:error, :invalid_order_key} == FractionalIndex.generate_key_between("0", "1")
+  end
+
+  test "generate_key_between() checks arguments" do
+    assert {:error, :invalid_order_key} ==
+             FractionalIndex.generate_key_between(nil, "A00000000000000000000000000")
+
+    assert {:error, :invalid_order_key} == FractionalIndex.generate_key_between("a00", nil)
+    assert {:error, :invalid_order_key} == FractionalIndex.generate_key_between("a00", "a1")
+    assert {:error, :wrong_order} == FractionalIndex.generate_key_between("a1", "a0")
   end
 end

--- a/test/fractional_index_test.exs
+++ b/test/fractional_index_test.exs
@@ -48,4 +48,8 @@ defmodule FractionalIndexTest do
     assert {:ok, "a0"} = FractionalIndex.generate_key_between("Zz", "a01")
     assert {:ok, "Zz"} = FractionalIndex.generate_key_between(nil, "a0")
   end
+
+  test ":invalid_order_key_head does not raise a MatchError" do
+    assert {:error, :invalid_order_key} == FractionalIndex.generate_key_between("0", "1")
+  end
 end


### PR DESCRIPTION
# Why?

Passing invalid keys to `generate_order_between()` was raising a `MatchError`, for example:
```elixir
FractionalIndex.generate_key_between("0", "1")
```
Caused:
```
      1) test generate_key_between() checks arguments (FractionalIndexTest)
         test/fractional_index_test.exs:52
         ** (MatchError) no match of right hand side value: {:error, :invalid_order_key_head}
         code: assert {:error, :invalid_order_key} == FractionalIndex.generate_key_between("0", "1")
         stacktrace:
           (fractional_index 0.1.0) lib/fractional_index.ex:136: FractionalIndex.validate_order_key/1
           (fractional_index 0.1.0) lib/fractional_index.ex:337: FractionalIndex.validate_input/1
           (fractional_index 0.1.0) lib/fractional_index.ex:252: FractionalIndex.generate_key_between/2
           test/fractional_index_test.exs:58: (test)
```

# What?

I simply let the error bubble up. I didn't bother bubbling up `:invalid_order_key_head` to the top caller, because I didn't want to make too much modifications. With this change we get `{:error, :invalid_order_key}`.

# How to test?

Run the tests.