### PR TITLE
Fix last digit popping in increment_integer()

### DIFF
--- a/lib/fractional_index.ex
+++ b/lib/fractional_index.ex
@@ -165,7 +165,7 @@ defmodule FractionalIndex do
           "#{h}#{digs}0"
 
         true ->
-          "#{h}#{String.slice(digs, 0..(String.length(digs) - 1))}"
+          "#{h}#{String.slice(digs, 0, String.length(digs) - 1)}"
       end
     else
       "#{head}#{digs}"

--- a/test/fractional_index_test.exs
+++ b/test/fractional_index_test.exs
@@ -63,6 +63,7 @@ defmodule FractionalIndexTest do
     assert {:ok, "a0"} == FractionalIndex.generate_key_between("Zz", "a01")
     assert {:ok, "a0"} == FractionalIndex.generate_key_between(nil, "a0V")
     assert {:ok, "b99"} == FractionalIndex.generate_key_between(nil, "b999")
+    assert {:ok, "Z0"} == FractionalIndex.generate_key_between("Yzz", "Z0G")
 
     assert {:ok, "A000000000000000000000000000V"} ==
              FractionalIndex.generate_key_between(nil, "A000000000000000000000000001")


### PR DESCRIPTION
There was an error in the way the last digit is popped:
```elixir
"#{h}#{String.slice(digs, 0..(String.length(digs) - 1))}"
```

The `0..(length - 1)` range actually represents the whole string.

Popping the last digit is better expressed with `String.slice/3`:
```elixir
"#{h}#{String.slice(digs, 0, String.length(digs) - 1)}"
```
This fixes an issue where generating an index between "Yzz" and "Z0G" was producing the index "Z00", which is an invalid fractional index. The code now produces "Z0", which is correct.